### PR TITLE
Typo fix in guide book

### DIFF
--- a/src/main/resources/data/miners/patchouli_books/guide_book/en_us/entries/fluid_absorber.json
+++ b/src/main/resources/data/miners/patchouli_books/guide_book/en_us/entries/fluid_absorber.json
@@ -33,7 +33,7 @@
         },
 		{
              "type": "multiblock",
-             "name": "No Support Caps",
+             "name": "Support Caps",
              "multiblock": {
                  "pattern": [
                 	["C   C","     ","  I  ","     ","C   C"],


### PR DESCRIPTION
In Guide book there is typo.
For Fluid Absorber it says "No Support Caps" on both pages, which is incorrect